### PR TITLE
Denotational semantics

### DIFF
--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -1,1 +1,10 @@
 ## p.47~ Denotational Semantics
+
+## p.48 表示的意味論の最初の挙動チェック
+
+```ruby
+Number.new(5).to_ruby
+# => "-> e { 5 }"
+Boolean.new(false).to_ruby
+# => "-> e { false }"
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -35,3 +35,12 @@ proc = eval(expression.to_ruby)
 proc.call({ x: 7 })
 # => 7
 ```
+
+## p.50 Add, LessThan のチェック
+
+```ruby
+Add.new(Variable.new(:x), Number.new(1)).to_ruby
+# => "-> e { (-> e { e[:x] }).call(e) + (-> e { 1 }).call(e) }"
+LessThan.new(Add.new(Variable.new(:x), Number.new(1)), Number.new(3)).to_ruby
+# => "-> e { (-> e { (-> e { e[:x] }).call(e) + (-> e { 1 }).call(e) }).call(e) < ↵ (-> e { 3 }).call(e) }"
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -44,3 +44,21 @@ Add.new(Variable.new(:x), Number.new(1)).to_ruby
 LessThan.new(Add.new(Variable.new(:x), Number.new(1)), Number.new(3)).to_ruby
 # => "-> e { (-> e { (-> e { e[:x] }).call(e) + (-> e { 1 }).call(e) }).call(e) < ↵ (-> e { 3 }).call(e) }"
 ```
+
+
+## p.50 人間の限界
+最終的に得られる表示は複雑なので、それが正しいかどうかを目で見て判断するのは困難。
+次のようにして確かめよう。
+
+```Ruby
+environment = { x: 3 }
+# => {:x=>3}
+proc = eval(Add.new(Variable.new(:x), Number.new(1)).to_ruby)
+# => #<Proc (lambda)>
+proc.call(environment)
+# => 4
+proc = eval(LessThan.new(Add.new(Variable.new(:x), Number.new(1)), Number.new(3)).to_ruby )
+# => #<Proc (lambda)>
+proc.call(environment)
+# => false
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -62,3 +62,15 @@ proc = eval(LessThan.new(Add.new(Variable.new(:x), Number.new(1)), Number.new(3)
 proc.call(environment)
 # => false
 ```
+
+## p.51 Assign
+```Ruby
+statement = Assign.new(:y, Add.new(Variable.new(:x), Number.new(1)))
+# => «y = x + 1»
+statement.to_ruby
+# => "-> e { e.merge({ :y => (-> e { (-> e { e[:x] }).call(e) + (-> e { 1 }).call(e) })↵ .call(e) }) }"
+proc = eval(statement.to_ruby)
+=> #<Proc (lambda)>
+proc.call({ x: 3 })
+=> {:x=>3, :y=>4}
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -8,3 +8,17 @@ Number.new(5).to_ruby
 Boolean.new(false).to_ruby
 # => "-> e { false }"
 ```
+
+
+## p.49 ドキドキ初めての Kernel#eval
+
+```ruby
+proc = eval(Number.new(5).to_ruby)
+# => #<Proc (lambda)>
+proc.call({})
+# => 5
+proc = eval(Boolean.new(false).to_ruby)
+# => #<Proc (lambda)>
+proc.call({})
+# => false
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -22,3 +22,16 @@ proc = eval(Boolean.new(false).to_ruby)
 proc.call({})
 # => false
 ```
+
+
+## p49 Check Variable
+```ruby
+expression = Variable.new(:x)
+# => «x»
+expression.to_ruby
+# => "-> e { e[:x] }"
+proc = eval(expression.to_ruby)
+# => #<Proc (lambda)>
+proc.call({ x: 7 })
+# => 7
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -74,3 +74,19 @@ proc = eval(statement.to_ruby)
 proc.call({ x: 3 })
 => {:x=>3, :y=>4}
 ```
+
+## p.52 While
+
+```ruby
+statement = While.new(
+  LessThan.new(Variable.new(:x), Number.new(5)),
+  Assign.new(:x, Multiply.new(Variable.new(:x), Number.new(3)))
+)
+# => «while (x < 5) { x = x * 3 }»
+statement.to_ruby
+# => "-> e { while (-> e { (-> e { e[:x] }).call(e) < (-> e { 5 }).call(e) }).call(e); e = (-> e { e.merge({ :x => (-> e { (-> e { e[:x] }).call(e) * (-> e { 3 }).call(e) ↵ }).call(e) }) }).call(e); end; e }"
+proc = eval(statement.to_ruby)
+# => #<Proc (lambda)>
+proc.call({ x: 1 })
+# => {:x=>9}
+```

--- a/denotational_semantics/NOTE.md
+++ b/denotational_semantics/NOTE.md
@@ -1,0 +1,1 @@
+## p.47~ Denotational Semantics

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -91,3 +91,9 @@ class If # args = {:condition, :consequence, :alternative}
     )
   end
 end
+
+class Sequence
+  def to_ruby
+    to_lambda_str "(#{second.to_ruby}).call((#{first.to_ruby}).call(e))"
+  end
+end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -1,6 +1,6 @@
 require '../../base_definitions.rb'
 
-def to_lambda_str(_inspect)
+def to_lambda_str(_inspect = "e")
   "-> e { #{_inspect} }"
 end
 
@@ -65,5 +65,11 @@ end
 class Assign # args = {:name, :expression}
   def to_ruby
     to_lambda_str "e.merge({ #{name.inspect} => (#{expression.to_ruby}).call(e) })"
+  end
+end
+
+class DoNothing
+  def to_ruby
+    to_lambda_str
   end
 end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -1,7 +1,13 @@
 require '../../base_definitions.rb'
 
 def to_lambda_str(_inspect = "e")
-  "-> e { #{_inspect} }"
+  build =-> str { "-> e { #{str} }" }
+  case _inspect
+  when String
+    build[_inspect]
+  when Array
+    build[_inspect.join("\s")]
+  end
 end
 
 class Number # args => {:value}
@@ -71,5 +77,17 @@ end
 class DoNothing
   def to_ruby
     to_lambda_str
+  end
+end
+
+class If # args = {:condition, :consequence, :alternative}
+  def to_ruby
+    to_lambda_str %W(
+      if (#{condition.to_ruby}).call(e) then
+        (#{consequence.to_ruby}).call(e)
+      else
+        (#{alternative.to_ruby}).call(e)
+      end
+    )
   end
 end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -59,3 +59,11 @@ class LessThan # args = {:left, :right}
     to_lambda_str "(#{left.to_ruby}).call(e) < (#{right.to_ruby}).call(e)"
   end
 end
+
+# Statements
+
+class Assign # args = {:name, :expression}
+  def to_ruby
+    to_lambda_str "e.merge({ #{name.inspect} => (#{expression.to_ruby}).call(e) })"
+  end
+end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -1,0 +1,13 @@
+require '../../base_definitions.rb'
+
+class Number # args => {:value}
+  def to_ruby
+    "-> e { #{value.inspect} }"
+  end
+end
+
+class Boolean
+  def to_ruby
+    "-> e { #{value.inspect} }"
+  end
+end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -1,13 +1,17 @@
 require '../../base_definitions.rb'
 
+def to_lambda_str(_inspect)
+  "-> e { #{_inspect} }"
+end
+
 class Number # args => {:value}
   def to_ruby
-    "-> e { #{value.inspect} }"
+    to_lambda_str value.inspect
   end
 end
 
 class Boolean
   def to_ruby
-    "-> e { #{value.inspect} }"
+    to_lambda_str value.inspect
   end
 end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -32,3 +32,30 @@ class Variable # args => {:name}
     to_lambda_str "e[#{name.inspect}]"
   end
 end
+
+
+
+##### ASTs whitch recieve sub-expression arguments #############################
+# We know that each subexpression will be denoted by a proc’s Ruby source,
+# so we can use them as part of a larger piece of Ruby source that calls
+# those procs with the supplied environment and does some computation
+# with their return values.
+################################################################################
+
+class Add # args = {:left, :right}
+  def to_ruby
+    to_lambda_str "(#{left.to_ruby}).call(e) + (#{right.to_ruby}).call(e)"
+  end
+end
+
+class Multiply # args = {:left, :right}
+  def to_ruby
+    to_lambda_str "(#{left.to_ruby}).call(e) * (#{right.to_ruby}).call(e)"
+  end
+end
+
+class LessThan # args = {:left, :right}
+  def to_ruby
+    to_lambda_str "(#{left.to_ruby}).call(e) < (#{right.to_ruby}).call(e)"
+  end
+end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -15,3 +15,20 @@ class Boolean
     to_lambda_str value.inspect
   end
 end
+
+class Variable # args => {:name}
+
+  ##############################################################################
+  # expression = Variable.new(:x)
+  # # => «x»
+  # expression.to_ruby
+  # # => "-> e { e[:x] }"
+  # proc = eval(expression.to_ruby)
+  # # => #<Proc (lambda)>
+  # proc.call({ x: 7 })
+  # # => 7
+  ##############################################################################
+  def to_ruby
+    to_lambda_str "e[#{name.inspect}]"
+  end
+end

--- a/denotational_semantics/src/definitions.rb
+++ b/denotational_semantics/src/definitions.rb
@@ -97,3 +97,14 @@ class Sequence
     to_lambda_str "(#{second.to_ruby}).call((#{first.to_ruby}).call(e))"
   end
 end
+
+class While
+  def to_ruby
+    to_lambda_str %W(
+      while (#{condition.to_ruby}).call(e);
+        e = (#{body.to_ruby}).call(e);
+      end;
+      e
+    )
+  end
+end


### PR DESCRIPTION
## [Column] Whileの比較


> The small-step operational semantics of «while» is written as a reduction rule for an abstract machine.
>
> The overall looping behavior isn’t part of the rule’s action reduction just turns a «while» statement into an «if» statement
> but it emerges as a consequence of the future reductions performed by the machine.
>
> To understand what «while» does, we need to look at all of the small-step rules
> and work out how they interact over the course of a SIMPLE program’s execution.

**Small Step 意味論**
```ruby
class While

  def reducible?
    true
  end

  def reduce(environment)
    [
      If.new(condition,
        Sequence.new(body, self),
        DoNothing.new
      ),
      environment
    ]
  end
end

```

---

> «while»’s big-step operational semantics is written as an evaluation rule that shows how to compute the final environment directly.
> The rule contains a recursive call to itself, so there’s an explicit indication that «while» will cause a loop during evaluation,
> but it’s not quite the kind of loop that a SIMPLE programmer would recognize.
>
> Big-step rules are written in a recursive style, describing the complete evaluation
> of an expression or statement in terms of the evaluation of other pieces of syntax,
> so this rule tells us that the result of evaluating a «while» statement may depend upon
> the result of evaluating the same statement in a different environment,
> but it requires a leap of intuition to connect this idea with the iterative behavior that
> «while» is supposed to exhibit.
>
> Fortunately the leap isn’t too large: a bit of mathematical reasoning can show that
> the two kinds of loop are equivalent in principle, and when the metalanguage supports
> tail call optimization, they’re also equivalent in practice.

**Big Step 意味論**
```ruby
class While # args = {:condition, :body}
  def evaluate(environment)
    case condition.evaluate(environment)
    when Boolean.new(true)
      evaluate(body.evaluate(environment))
    when Boolean.new(false)
      environment
    end
  end
end
```

---

> The denotational semantics of «while» shows how to rewrite it in Ruby,
> namely by using Ruby’s while keyword.
>
> This is a much more direct translation: Ruby has native support for iterative loops,
> and the denotation rule shows that «while» can be implemented with that feature.
>
> There’s no leap required to understand how the two kinds of loop relate to each other,
> so if we understand how Ruby while loops work, we understand SIMPLE «while» loops too.
>
> Of course, this means we’ve just converted the problem of understanding SIMPLE into
> the problem of understanding the denotation language, which is a serious disadvantage when
> that language is as large and ill-specified as Ruby, but it becomes an advantage when
> we have a small mathematical language for writing denotations.

** 表示的 意味論**
```ruby
class While
  def to_ruby
    to_lambda_str %W(
      while (#{condition.to_ruby}).call(e);
        e = (#{body.to_ruby}).call(e);
      end;
      e
    )
  end
end
```
